### PR TITLE
feat: adding a test for testing the default amount of related products on article page

### DIFF
--- a/components/related_products.py
+++ b/components/related_products.py
@@ -4,7 +4,7 @@ class RelatedProducts(BaseComponent):
     def __init__(self, page: Page):
         super().__init__(page)
         self.page = page
-        self.related_products = page.locator("div[class*='content-related'] div.product-thumb")
+        self.related_products = page.locator("div[class*='content-related'] div.product-thumb, div.product-thumb.image-top")
         self.add_to_cart_buttons = "button[class*='btn-cart']"
         self.wishlist_buttons = "button[class*='btn-wishlist']"
         self.compare_buttons = "button[class*='btn-compare']"

--- a/pages/article_page.py
+++ b/pages/article_page.py
@@ -1,6 +1,7 @@
 from playwright.sync_api import Page
 from pages.base_page import BasePage
 from components.comment_form import CommentForm
+from components.related_products import RelatedProducts
 
 class ArticlePage(BasePage):
 
@@ -9,6 +10,7 @@ class ArticlePage(BasePage):
 
         # Components
         self.comment_form = CommentForm(page)
+        self.related_products = RelatedProducts(page)
 
         # Locators
         self.page_title = self.page.locator("h1.h1")

--- a/tests/articles/test_articles.py
+++ b/tests/articles/test_articles.py
@@ -177,3 +177,17 @@ class TestArticles(BaseTest):
 
         # Check that the amount of visible comments is 20
         expect(self.article_page.comments).to_have_count(20)
+
+    def test_the_amount_of_related_products(self):
+        # Navigate to the home page
+        self.home_page.goto()
+
+        # Scroll to the articles section
+        self.home_page.articles.scroll_to_articles()
+
+        # Click on the first article
+        first_article = self.home_page.articles.article_items.nth(0)
+        first_article.click()
+
+        # Check that the amount of related products is 8
+        expect(self.article_page.related_products.related_products).to_have_count(8, timeout=10000)


### PR DESCRIPTION
- Updated the RelatedProducts component to include an additional locator for products with the 'image-top' class.
- Integrated the RelatedProducts component into the ArticlePage class for improved product visibility.
- Added a new test case to verify the count of related products displayed on the article page, ensuring it matches the expected number of 8.